### PR TITLE
Fix React peer dependency syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "start": "rollup -c -w"
   },
   "dependencies": {
-    "use-supabase": "^1.0.1"
   },
   "peerDependencies": {
-    "react": ">= 16.8.0 < 2",
-    "react-dom": ">= 16.8.0 < 2"
+    "react": ">= 16.8.0",
+    "react-dom": ">= 16.8.0",
+    "@supabase/supabase-js": ">= 1.4.1"
   },
   "devDependencies": {
     "@supabase/supabase-js": "^1.4.1",


### PR DESCRIPTION
Invalid version range causes a warning on installation and self-dependency is pointless. Fixes #5