### PR TITLE
Align error api with SWR

### DIFF
--- a/src/hooks/useQuery.tsx
+++ b/src/hooks/useQuery.tsx
@@ -23,7 +23,7 @@ export function useQuery<T>(query: PostgrestBuilder<T>) {
     const { data, error } = await query
 
     if (error) {
-      return error
+      throw error
     }
 
     return data

--- a/src/hooks/useTable.tsx
+++ b/src/hooks/useTable.tsx
@@ -38,7 +38,7 @@ export function useTable<T>(from: string, select: SelectArg = '*') {
       .select(selectStr, selectOptions)
 
     if (error) {
-      return error
+      throw error
     }
 
     return data


### PR DESCRIPTION
This fixes the misalignment of the current api with that of the standard SWR and Supabase apis.

That is the `useQuery` hook should now return any errors in the `error` key rather than the `data` key